### PR TITLE
Use selected text for gist, if available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: gistfo
 Title: Get it Somewhere The F Online
 Version: 0.0.1
 Authors@R: person("Miles", "McBain", email = "miles.mcbain@gmail.com", role = c("aut", "cre"))
-Description: Sends the currently active RStudio tab to Github as a private gist. 
+Description: Sends the currently active RStudio tab or selection to Github as a private gist. 
              Can also create a public gist and send to carbon.now.sh for easy Tweeting of saucy code pic.
 Depends: R (>= 3.4.0)
 Imports: 
@@ -13,3 +13,4 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
+Roxygen: list(markdown = TRUE)

--- a/R/gistfo.R
+++ b/R/gistfo.R
@@ -38,11 +38,13 @@ gistfo_base <- function(mode){
           project <- ""
         }
         gist_name <- paste("RStudio",project,name, sep="_")
+        gist_content <- source_context$selection[[1]]$text
+        if (gist_content == "") gist_content <- paste0(source_context$contents, collapse = "\n")
 
         the_gist <- gistr::gist_create(filename = gist_name,
                            public = public,
                            browse = browse,
-                           code = paste0(source_context$contents, collapse = "\n")
+                           code = gist_content
                            )
         if(mode == "carbon"){
           browseURL(paste0(CARBON_URL, the_gist$url))

--- a/R/gistfo.R
+++ b/R/gistfo.R
@@ -1,16 +1,23 @@
 CARBON_URL <- "https://carbon.now.sh/?bg=rgba(0,0,0,0)&t=solarized%20dark&l=r&ds=true&wc=true&wa=true&pv=48px&ph=32px&ln=true"
 
-#' Create a private Github gist containing the active RStudio tab and browse to it.
-#' File is named: RStudio_<project>_<filename or file_id>. file_id is a unique id for
-#' untitled files. It does not relate to the untitled number.
+#' Create a private Github gist and browse to it.
+#'
+#' The gist will contain the active text selection or the active RStudio tab.
+#' File is named: `RStudio_<project>_<?selection>_<filename or file_id>`.
+#' `file_id` is a unique id for untitled files. It does not relate to the
+#' untitled number.
 #' @return nothing.
 #' @export
 gistfo <- function() gistfo_base(mode = "gistfo")
 
-#' Create a public Github gist containing the active RStudio tab and browse to it,
-#' then open the gist in carbon.now.sh, for easily Tweeting a saucy code pic.
-#' Gist file is named: RStudio_<project>_<filename or file_id>. file_id is a unique id for
-#' untitled files. It does not relate to the untitled number.
+#' Create a public Github gist and send to carbon.now.sh, then browse to both.
+#'
+#' Create a public Github gist and browse to it, then open the gist in
+#' [carbon.now.sh](https://carbon.now.sh), for easily Tweeting a saucy code pic.
+#' The gist will contain the active text selection or the active RStudio tab.
+#' Gist file is named: `RStudio_<project>_<?selection>_<filename or file_id>`.
+#' `file_id` is a unique id for untitled files. It does not relate to the
+#' untitled number.
 #' @return nothing.
 #' @export
 gistfoc <- function() gistfo_base(mode = "carbon")
@@ -37,9 +44,13 @@ gistfo_base <- function(mode){
         }else{
           project <- ""
         }
-        gist_name <- paste("RStudio",project,name, sep="_")
         gist_content <- source_context$selection[[1]]$text
-        if (gist_content == "") gist_content <- paste0(source_context$contents, collapse = "\n")
+        if (gist_content == "") {
+          gist_name <- paste("RStudio",project,name, sep="_")
+          gist_content <- paste0(source_context$contents, collapse = "\n")
+        } else {
+          gist_name <- paste("RStudio",project,"selection",name, sep="_")
+        }
 
         the_gist <- gistr::gist_create(filename = gist_name,
                            public = public,

--- a/R/gistfo.R
+++ b/R/gistfo.R
@@ -27,7 +27,7 @@ gistfo_base <- function(mode){
         }
         source_context <- rstudioapi::getSourceEditorContext()
         if(source_context$path == ''){
-          name <- paste("unititled",source_context$id,sep = "_")
+          name <- paste("untitled",source_context$id,sep = "_")
         }else{
           name <- tail(unlist(strsplit(x = source_context$path, split = "/")), 1)
         }

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ install_github("MilesMcBain/gistfo")
 ## Usage
 
 ### As an addin
-From the RStudio Addins menu select either `Make Tab into Gist` or `Send Tab as Gist to Carbon`.
+Select the text or source file tab you would like to turn into a Gist.
+Then, from the RStudio Addins menu select either `Make Gist from Text or Tab` or `Make Gist and Send to Carbon`.
 
 ### From the console
 ```
 library(gistfo)
 ```
-Make sure an RStudio tab is active, then run `gistfo()`. It will open a browser window asking you to authenticate a third-party OAuth application. Should be all good from there. 
+Make sure an RStudio tab is active or select text in a source file, then run `gistfo()`. It will open a browser window asking you to authenticate a third-party OAuth application. Should be all good from there. 
 
 Carbon mode: `gistfoc()`

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,9 +1,9 @@
-Name: Make Tab into Gist
-Description: Sends the active RStudio source editor to Github as a private gist.
+Name: Make Gist from Text or Tab
+Description: Sends the active selection or RStudio source editor to Github as a private gist.
 Binding: gistfo
 Interactive: yes
 
-Name: Send Tab as Gist to Carbon
-Description: Sends the active RStudio source editor to Github as a public gist. Opens in carbon.sh.
+Name: Make Gist and Send to Carbon
+Description: Sends the active selection or RStudio source editor to Github as a public gist. Opens in carbon.sh.
 Binding: gistfoc
 Interactive: yes

--- a/man/gistfo.Rd
+++ b/man/gistfo.Rd
@@ -2,9 +2,7 @@
 % Please edit documentation in R/gistfo.R
 \name{gistfo}
 \alias{gistfo}
-\title{Create a private Github gist containing the active RStudio tab and browse to it.
-File is named: RStudio_<project>_<filename or file_id>. file_id is a unique id for
-untitled files. It does not relate to the untitled number.}
+\title{Create a private Github gist and browse to it.}
 \usage{
 gistfo()
 }
@@ -12,7 +10,8 @@ gistfo()
 nothing.
 }
 \description{
-Create a private Github gist containing the active RStudio tab and browse to it.
-File is named: RStudio_<project>_<filename or file_id>. file_id is a unique id for
-untitled files. It does not relate to the untitled number.
+The gist will contain the active text selection or the active RStudio tab.
+File is named: \code{RStudio_<project>_<?selection>_<filename or file_id>}.
+\code{file_id} is a unique id for untitled files. It does not relate to the
+untitled number.
 }

--- a/man/gistfoc.Rd
+++ b/man/gistfoc.Rd
@@ -2,10 +2,7 @@
 % Please edit documentation in R/gistfo.R
 \name{gistfoc}
 \alias{gistfoc}
-\title{Create a public Github gist containing the active RStudio tab and browse to it,
-then open the gist in carbon.now.sh, for easily Tweeting a saucy code pic.
-The Gist URL is copied to your clipboard in case you want to paste it
-into your carbon tweet.}
+\title{Create a public Github gist and send to carbon.now.sh, then browse to both.}
 \usage{
 gistfoc()
 }
@@ -13,6 +10,10 @@ gistfoc()
 nothing.
 }
 \description{
-Gist file is named: RStudio_<project>_<filename or file_id>. file_id is a unique id for
-untitled files. It does not relate to the untitled number.
+Create a public Github gist and browse to it, then open the gist in
+\href{https://carbon.now.sh}{carbon.now.sh}, for easily Tweeting a saucy code pic.
+The gist will contain the active text selection or the active RStudio tab.
+Gist file is named: \code{RStudio_<project>_<?selection>_<filename or file_id>}.
+\code{file_id} is a unique id for untitled files. It does not relate to the
+untitled number.
 }


### PR DESCRIPTION
Hey @MilesMcBain, thanks for putting this package together!

I made a small change to `gistfo()` to use the currently selected text for the gist (if available), falling back to the source file if no text is selected. While I was poking around I also fixed a typo and updated the addins dropdown list menu items.

No pressure to merge or keep all of my changes, just thought I'd share my tweaks.