### PR TITLE
Append gist url if sending to carbon

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,10 @@ Imports:
     rstudioapi (>= 0.6),
     gistr (>= 0.4.0),
     clipr (>= 0.3.0)
+Suggests:
+    curl  (>= 1.0)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 Roxygen: list(markdown = TRUE)

--- a/R/gistfo.R
+++ b/R/gistfo.R
@@ -52,14 +52,31 @@ gistfo_base <- function(mode){
           gist_name <- paste("RStudio",project,"selection",name, sep="_")
         }
 
-        the_gist <- gistr::gist_create(filename = gist_name,
+        gist_file <- file.path(tempdir(), gist_name)
+        cat(gist_content, file = gist_file)
+        the_gist <- gistr::gist_create(files = gist_file,
                            public = public,
-                           browse = browse,
-                           code = gist_content
-                           )
+                           browse = browse)
         if(mode == "carbon"){
-          browseURL(paste0(CARBON_URL, the_gist$url))
+          # Add URL to gist as comment at bottom of gist
+          gist_url <- url_git_io(the_gist$url)
+          cat("\n\n#", gist_url, file = gist_file, append = TRUE)
+          the_gist <- gistr::update_files(the_gist, gist_file)
+          gistr::update(the_gist)
+
+          # Send to carbon
+          utils::browseURL(paste0(CARBON_URL, the_gist$url))
           clipr::write_clip(the_gist$url)
         }
         invisible(NULL)
+}
+
+# Create Shortlink for URL using git.io
+url_git_io <- function(url) {
+        if (!requireNamespace("curl", quietly = TRUE)) return(url)
+        h <- curl::new_handle()
+        curl::handle_setform(h, url = url)
+        r <- curl::curl_fetch_memory("https://git.io", h)
+        if (!r$status %in% 200:203) return(url)
+        curl::parse_headers_list(r$headers)$location
 }

--- a/R/gistfo.R
+++ b/R/gistfo.R
@@ -78,5 +78,6 @@ url_git_io <- function(url) {
         curl::handle_setform(h, url = url)
         r <- curl::curl_fetch_memory("https://git.io", h)
         if (!r$status %in% 200:203) return(url)
-        curl::parse_headers_list(r$headers)$location
+        short_url <- curl::parse_headers_list(r$headers)$location
+        if (!is.null(short_url) && grepl("git\\.io", short_url)) short_url else url
 }


### PR DESCRIPTION
I hear there's a new carbonate package on the block, but I'll always have a soft spot for gistfo.

Carbon images of code look great but aren't exactly portable, so I added a small bit of code to create the gist and then append the link as a comment at the end of the file before sending off to carbon.

It uses https://git.io as shortlink service, but falls back to full gist url if that doesn't work or if `curl` isn't installed. I added curl as suggests, but it's pretty much guaranteed to be there since this package lives on GitHub.

Notes: I had to write out the code to a temp file and send the file in the `gistr::gist_create()` call instead of passing the code snippet directly so that I could later write the url and update the file. FYI git.io only works on github urls. Also, spaces _**and**_ tabs FTW!